### PR TITLE
Reduced container size by 80% and accelerated builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 token.secret
 *.crt
 env/
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM centos:7
+FROM python:2-alpine
+
+COPY requirements.txt requirements.txt
+RUN pip --no-cache-dir install -r requirements.txt
 
 COPY imgs imgs
-COPY niwidbot.py niwidbot.py
-COPY requirements.txt requirements.txt
-COPY token.secret token.secret
 
-RUN yum -y install epel-release
-RUN yum -y install python-pip
-RUN pip install -r requirements.txt
+COPY niwidbot.py niwidbot.py
+COPY token.secret token.secret
 
 CMD python niwidbot.py


### PR DESCRIPTION
Switched base docker image from centos:7 to python:2-alpine, reducing final image size from ~380MB to ~76MB. Reordered Dockerfile to make better use of cache layers for faster repeated builds.